### PR TITLE
썸네일 생성 기능 수정

### DIFF
--- a/src/main/java/com/hanghae/lemonairtranscoding/controller/TranscodeController.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/controller/TranscodeController.java
@@ -17,7 +17,10 @@ public class TranscodeController {
 	private final TranscodeService transcodeService;
 
 	@GetMapping("/{owner}")
-	Mono<Long> startTransCoding(@PathVariable("owner") String owner){
-		return transcodeService.start(owner);
+	Mono<Long> startTransCoding(@PathVariable("owner") String email){
+		// TODO: 2023-12-05 현재는 obs studio가 보낸 요청으로부터 사용자 정보의 수정 없이 전달되므로
+		//  email 자체가 전송된다. @ 이전 부분만 사용
+		email = email.substring(0,email.indexOf("@"));
+		return transcodeService.start(email);
 	}
 }


### PR DESCRIPTION
controller로 transcoding 요청이 온 경우 현재 localhost/email@gmail.com 등으로 요청이 날아오고있어서,  email@gmail.com 의 디렉토리로 영상 자료들을 저장할 수 없어서 Controller 단에서 @ 앞의 문자열만 디렉토리 이름으로 사용하도록 service에 전달합니다.

썸네일에 일련번호를 부여하는 명령어가 날아가도록 수정했습니다.