### PR TITLE
트랜스코딩 과정 리팩토링 및 버그 수정 및  썸네일 업로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,6 @@ dependencies {
 //    implementation('software.amazon.awssdk:s3')
 }
 
-//tasks.named('test') {
-//    useJUnitPlatform()
-//}
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.projectreactor.addons:reactor-extra:3.5.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -31,8 +33,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation "io.awspring.cloud:spring-cloud-starter-aws:2.4.4"
-//    implementation(platform("software.amazon.awssdk:bom:2.21.1"))
-//    implementation('software.amazon.awssdk:s3')
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hanghae/lemonairtranscoding/ffmpeg/FFmpegCommandConstants.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/ffmpeg/FFmpegCommandConstants.java
@@ -56,4 +56,8 @@ public class FFmpegCommandConstants {
 
 	public static final int SEGMENTLIST_ALL = 0;
 
+	public static final int THUMBNAIL_CREATE_STRATEGY_UPDATE = 0;
+	public static final int THUMBNAIL_CREATE_STRATEGY_TIMESTAMP = 1;
+	public static final int THUMBNAIL_CREATE_STRATEGY_SEQUENCE = 2;
+
 }

--- a/src/main/java/com/hanghae/lemonairtranscoding/service/AwsService.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/service/AwsService.java
@@ -1,0 +1,46 @@
+package com.hanghae.lemonairtranscoding.service;
+
+import java.io.File;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsService {
+	private final AmazonS3 amazonS3;
+
+	@Value("${ffmpeg.output.directory}")
+	private String outputPath;
+
+	@Value("${aws.s3.bucket}")
+	private String bucket;
+
+	private final String PREFIX_M3U8 = "m3u8-";
+
+	public String uploadToS3(String filePath) {
+		String key = getS3UploadKey(filePath);
+		PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, key, new File(filePath));
+		amazonS3.putObject(putObjectRequest);
+
+		String uploadedUrl = amazonS3.getUrl(bucket, key).toString();
+		log.info(uploadedUrl);
+		return uploadedUrl;
+	}
+
+
+	private String getS3UploadKey(String filePath){
+		String key = filePath.substring(outputPath.length() + 1).replaceAll("\\\\", "/");
+		if (key.startsWith(PREFIX_M3U8)) {
+			key = key.substring(PREFIX_M3U8.length());
+		}
+		return key;
+	}
+}

--- a/src/main/java/com/hanghae/lemonairtranscoding/service/TranscodeService.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/service/TranscodeService.java
@@ -76,6 +76,7 @@ public class TranscodeService {
 					.log()
 					.subscribe(line -> uploadFile(line, uploadedFiles));
 				}).subscribeOn(ffmpegProcessScheduler).log().subscribe();
+
 		return Mono.just(1L);
 	}
 

--- a/src/main/java/com/hanghae/lemonairtranscoding/service/TranscodeService.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/service/TranscodeService.java
@@ -74,7 +74,7 @@ public class TranscodeService {
 					.publishOn(awsUploadScheduler)
 					.map(this::uploadS3)
 					.log()
-					.subscribe(line -> uploadFile(line, uploadedFiles));
+					.subscribe(line -> addToUploadList(line, uploadedFiles));
 				}).subscribeOn(ffmpegProcessScheduler).log().subscribe();
 
 		return Mono.just(1L);
@@ -88,6 +88,7 @@ public class TranscodeService {
 		}
 		String key = line.substring(outputPath.length() + 1).replaceAll("\\\\", "/");
 		PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, key, new File(line));
+		amazonS3.putObject(putObjectRequest);
 		return amazonS3.getUrl(bucket, key).toString();
 	}
 
@@ -124,7 +125,7 @@ public class TranscodeService {
 		return processBuilder;
 	}
 
-	void uploadFile(String filePath, List<String> uploadedFileList) {
+	void addToUploadList(String filePath, List<String> uploadedFileList) {
 		uploadedFileList.add(filePath);
 		uploadedFileList.stream().forEach(System.out::println);
 	}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -3,3 +3,8 @@ server:
 
 upload:
   s3: true
+
+ffmpeg:
+  debug: false
+  thumbnail:
+    creation-cycle: 10

--- a/src/test/java/com/hanghae/lemonairtranscoding/awstest/AwsS3Test.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/awstest/AwsS3Test.java
@@ -24,6 +24,13 @@ public class AwsS3Test {
 	}
 
 	@Test
+	void uploadFileTest2(){
+		File file = new File("C:\\Users\\sbl\\Desktop\\uploadtest.txt.txt");
+		amazonS3.putObject("lemonair-streaming", "lyulbyung/videos", file);
+	}
+
+
+	@Test
 	void checkFiles(){
 		S3Object s3Object = amazonS3.getObject("lemonair-streaming", "sbl/sm2");
 		System.out.println("s3Object.getObjectContent().toString() = " + s3Object.getObjectContent().toString());

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/AvoidFlatMapTest.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/AvoidFlatMapTest.java
@@ -1,9 +1,16 @@
 package com.hanghae.lemonairtranscoding.learntest.webflux;
 
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.function.TupleUtils;
 import reactor.test.StepVerifier;
 
 public class AvoidFlatMapTest {
@@ -12,53 +19,20 @@ public class AvoidFlatMapTest {
 		return Flux.just(String.format("%d를 문자열로 변환하기", number));
 	}
 
-	// private ArrayList<?>[][] results;
-	// private ArrayList<String>[] stringResults;
-	// private ArrayList<Integer>[] integerResults;
-	//
-	// private final int NUM_TYPE = 2;
-	// private final int NUM_STREAMS = 2;
-	// @BeforeEach
-	// void beforeEach(){
-	// 	// stringResults = new ArrayList[NUM_STREAMS];
-	// 	// for (int i = 0; i < 2; i++) {
-	// 	// 	stringResults[i] = new ArrayList<>();
-	// 	// }
-	// 	results = new ArrayList[NUM_TYPE][NUM_STREAMS];
-	// 	for (int i = 0; i < NUM_TYPE; i++) {
-	// 		ArrayList<?>[] tempResults = new ArrayList[NUM_STREAMS];
-	// 		for (int j = 0; j < NUM_STREAMS; j++) {
-	// 			tempResults[i] = new ArrayList<>();
-	// 		}
-	// 		results[i] = tempResults;
-	// 	}
-	// }
-	//
-	// @AfterEach
-	// void afterEach(){
-	// 	stringResults = new ArrayList[2];
-	// 	for (int i = 0; i < 2; i++) {
-	// 		stringResults[i] = new ArrayList<>();
-	// 	}
-	// }
-
 	@Test
 	void applySrpInFlatMap() {
 		//given
 		// 대부분의 경우 flatMap은 유용하지만 아래와 같은 경우 flatMap 안에서 Flux Stream 내의 요소를
 		// 직접 조작한 뒤 다른 reactive operation에 적용하고 있다.
 		// 해당 flatMap에 책임이 2개임
-		Flux<String> flatMapFlux = Flux.just(-1, 0, 1)
-			.flatMap(myNumber -> {
-				// get newNumber
-				int newNumber = myNumber * 3 - 1;
-				return getStringFlux(newNumber);
-			});
+		Flux<String> flatMapFlux = Flux.just(-1, 0, 1).flatMap(myNumber -> {
+			// get newNumber
+			int newNumber = myNumber * 3 - 1;
+			return getStringFlux(newNumber);
+		});
 
 		// 개선된 코드
-		Flux<String> mapFlux = Flux.just(-1, 0, 1)
-			.map(myNumber -> myNumber * 3 - 1)
-			.flatMap(this::getStringFlux);
+		Flux<String> mapFlux = Flux.just(-1, 0, 1).map(myNumber -> myNumber * 3 - 1).flatMap(this::getStringFlux);
 
 		//when
 
@@ -75,25 +49,157 @@ public class AvoidFlatMapTest {
 	}
 
 	@Test
-	void useMapRatherThanReturningMonoInFlatMap() {
+	void useMapInsteadOfReturningMonoInFlatMap() {
 		//given
-		Flux<Integer> returnMonoInFlatMapFlux = Flux.just(-1, 0, 1)
-			.flatMap(myNumber -> Mono.just(myNumber + 1));
+		Flux<Integer> returnMonoInFlatMapFlux = Flux.just(-1, 0, 1).flatMap(myNumber -> Mono.just(myNumber + 1));
 
-		Flux<Integer> mapFlux = Flux.just(-1, 0, 1)
-			.map(myNumber -> myNumber + 1);
+		Flux<Integer> mapFlux = Flux.just(-1, 0, 1).map(myNumber -> myNumber + 1);
 
 		//when
-		StepVerifier.create(returnMonoInFlatMapFlux)
-			.expectNext(0)
-			.expectNext(1)
-			.expectNext(2)
-			.verifyComplete();
-		StepVerifier.create(mapFlux)
-			.expectNext(0)
-			.expectNext(1)
-			.expectNext(2)
-			.verifyComplete();
+		StepVerifier.create(returnMonoInFlatMapFlux).expectNext(0).expectNext(1).expectNext(2).verifyComplete();
+		StepVerifier.create(mapFlux).expectNext(0).expectNext(1).expectNext(2).verifyComplete();
 	}
+
+	@Test
+	void emptyPublisherWhenUsingFilter() {
+		// given
+		// 자신의 mock 객체를 만들어서 목객체의 비즈니스로직을 filter 이후에 둬서
+		// filter가 emtpy publisher 인 경우 비즈니스로직이 수행되는지 테스트
+		AvoidFlatMapTest mockThis = Mockito.spy(new AvoidFlatMapTest());
+		Flux<String> emptyPublisherFlux = Flux.just(-1, 0, 1).filter(i -> i > 2).flatMap(mockThis::myBusinessLogic);
+		// when
+		List<String> results = new ArrayList<>();
+		emptyPublisherFlux.subscribe(results::add);
+
+		// then
+		assert results.isEmpty();
+		verify(mockThis, never()).myBusinessLogic(Mockito.anyInt());
+
+	}
+
+	private Flux<String> myBusinessLogic(int str) {
+		return Flux.just(String.valueOf(str));
+	}
+
+	// 위처럼 filter를 사용하는 경우 Empty Publisher가 되었을 가능성이 항상 0이 될 순 없기 때문에,
+	// 비즈니스로직이 수행되지 않는 상황을 피하려면 switchIfEmpty나 defaultIfEmpty를 사용해야함
+
+	// switchIfEmpty의 경우, filter 등에 의해 여태까지의 publisher chain 이 empty publisher인 경우
+	// swithchIfEmpty에서 리턴하는 요소가 추가된다.
+
+	@Test
+	void switchIfEmpty() {
+		// given
+		Flux<String> flux = Flux.just(-1, 0, 1)
+			.filter(num -> num > 2)
+			.flatMap(num -> Flux.just(String.valueOf(num)))
+			.switchIfEmpty(Mono.just("switchIfEmpty"));
+		// when then
+		StepVerifier.create(flux).expectNext("switchIfEmpty").verifyComplete();
+	}
+
+	@Test
+	void filterWhen() {
+		// given
+
+		// 안좋은 예
+		// 깔끔해보이긴 하지만 중첩 구조의 flatMap 을 사용중이다. 코드에 문제가 생겼을 때 건들기에 난이도가 높음
+		// 심지어 중첩된 flatMap에서는 해당 스트림에서 요소로 들어있는 name을 사용하는 것이 아니라 상위 스트림의 id를 사용중이다.
+		// 오해하기 좋은 코드이다.
+		Flux<String> badFlux = Flux.just(-1, 0, 1)
+			.flatMap(id -> getName(id).filter(name -> !"john".equals(name)).flatMap(name -> reactiveOperation(id)));
+
+		// 좋은 예, filterWhen -> map을 이용해서 복잡한 조건의 filter를 수행한 뒤 가공된 id로 flatMap을 수행하고 있음
+		Flux<String> goodFlux = Flux.just(-1, 0, 1)
+			.filterWhen(id -> getName(id).map(name -> !"john".equals(name)))
+			.flatMap(this::reactiveOperation);
+
+		// when then
+		StepVerifier.create(badFlux).expectNext("-2").expectNext("0").verifyComplete();
+
+		StepVerifier.create(goodFlux).expectNext("-2").expectNext("0").verifyComplete();
+	}
+
+	private Flux<String> reactiveOperation(Integer id) {
+		return Flux.just(String.valueOf(id * 2));
+	}
+
+	private Flux<String> getName(int id) {
+		if (id == 1)
+			return Flux.just("john");
+		return Flux.just("Alice");
+	}
+
+	/**
+	 * 두 Mono 사이 종속성이 없는 경우 간단하게 Mono.zip()을 활용하여
+	 * 두 Mono의 값으로 비즈니스 로직을 수행할 수 있다. Mono<Tuple<M1,M2>> 를 반환한다.
+	 */
+	@Test
+	void zip() {
+		// given
+		Mono<String> loginMono = Mono.zip(getKey(), getPassword())
+			.flatMap(tuple -> login(tuple.getT1(), tuple.getT2()));
+		// when then
+		StepVerifier.create(loginMono).expectNext("jwt토큰").verifyComplete();
+	}
+
+	/**
+	 * 두 Mono 사이 종속성이 존쟇나느 경우 zipWhen()을 사용할 수 잇다.
+	 * 직관적으로 두 Mono의 값을 가져오는 zip() 메서드와 달리 두 Mono간 Publisher 역할을 하는 Mono가 요소를 생산했을 때,
+	 * publisher 역할의 Mono의 값으로 subscriber 역할의 Mono의 값을 생성하여 이후 Mono<Tuple<P,S>> 를 반환한다.
+	 */
+	@Test
+	void zipWhen() {
+		// given
+		Mono<String> passwordVerifyMono =
+			getPassword()
+			.zipWhen(this::encryptPassword)
+			.flatMap(tuple -> login(tuple.getT1(), tuple.getT2()));
+		// when
+		// then
+
+		StepVerifier.create(passwordVerifyMono).expectNext("jwt토큰").verifyComplete();
+	}
+
+	/**
+	 * zip() 이든 zipWhen()이든 사용하다보면, tuple을 완성하여 생성하고, 요청해서 비즈니스 로직에서 tuple.getTN() 을 이용해서 튜플을 사용할 때
+	 * 조금 사용하기 곤란함을 느꼈을 것이다.
+	 * TupleUtils.function() 을 사용하면 Tuple에서 요소들을 꺼내서 바로 사용할 수 있도록 해준다.
+	 */
+
+	@Test
+	void tupleUtils_function(){
+	    // given
+	    Mono<String> loginMono = Mono.zip(getKey(), getPassword())
+			.flatMap(TupleUtils.function(this::login));
+	    // when
+	    // then
+		StepVerifier.create(loginMono).expectNext("jwt토큰").verifyComplete();
+	}
+
+	@Test
+	void delayUntil(){
+	    Flux.just(1,2,3,4,5).log().delayUntil(i -> Flux.just(i * 10)).log().subscribe();
+		// log를 찍어보면 ConcatMapNoPrefetch 클래스가 onNext를 호출하며 이전에 요청받은 데이터를 처리하고나서 새로운 요소를 요청한다.
+	}
+
+	private Mono<String> encryptPassword(String password) {
+		return Mono.just(password + "까꿍");
+	}
+
+	private Mono<String> login(String t1, String t2) {
+		//어?쩌구 쿵쾅쿵쾅 로직
+		return Mono.just("jwt토큰");
+	}
+
+	private Mono<String> getKey() {
+		return Mono.just("sbl1998");
+	}
+
+	private Mono<String> getPassword() {
+		return Mono.just("qwer1234");
+	}
+
+
 
 }

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/AvoidFlatMapTest.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/AvoidFlatMapTest.java
@@ -1,0 +1,99 @@
+package com.hanghae.lemonairtranscoding.learntest.webflux;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class AvoidFlatMapTest {
+
+	public Flux<String> getStringFlux(int number) {
+		return Flux.just(String.format("%d를 문자열로 변환하기", number));
+	}
+
+	// private ArrayList<?>[][] results;
+	// private ArrayList<String>[] stringResults;
+	// private ArrayList<Integer>[] integerResults;
+	//
+	// private final int NUM_TYPE = 2;
+	// private final int NUM_STREAMS = 2;
+	// @BeforeEach
+	// void beforeEach(){
+	// 	// stringResults = new ArrayList[NUM_STREAMS];
+	// 	// for (int i = 0; i < 2; i++) {
+	// 	// 	stringResults[i] = new ArrayList<>();
+	// 	// }
+	// 	results = new ArrayList[NUM_TYPE][NUM_STREAMS];
+	// 	for (int i = 0; i < NUM_TYPE; i++) {
+	// 		ArrayList<?>[] tempResults = new ArrayList[NUM_STREAMS];
+	// 		for (int j = 0; j < NUM_STREAMS; j++) {
+	// 			tempResults[i] = new ArrayList<>();
+	// 		}
+	// 		results[i] = tempResults;
+	// 	}
+	// }
+	//
+	// @AfterEach
+	// void afterEach(){
+	// 	stringResults = new ArrayList[2];
+	// 	for (int i = 0; i < 2; i++) {
+	// 		stringResults[i] = new ArrayList<>();
+	// 	}
+	// }
+
+	@Test
+	void applySrpInFlatMap() {
+		//given
+		// 대부분의 경우 flatMap은 유용하지만 아래와 같은 경우 flatMap 안에서 Flux Stream 내의 요소를
+		// 직접 조작한 뒤 다른 reactive operation에 적용하고 있다.
+		// 해당 flatMap에 책임이 2개임
+		Flux<String> flatMapFlux = Flux.just(-1, 0, 1)
+			.flatMap(myNumber -> {
+				// get newNumber
+				int newNumber = myNumber * 3 - 1;
+				return getStringFlux(newNumber);
+			});
+
+		// 개선된 코드
+		Flux<String> mapFlux = Flux.just(-1, 0, 1)
+			.map(myNumber -> myNumber * 3 - 1)
+			.flatMap(this::getStringFlux);
+
+		//when
+
+		StepVerifier.create(flatMapFlux)
+			.expectNext("-4를 문자열로 변환하기")
+			.expectNext("-1를 문자열로 변환하기")
+			.expectNext("2를 문자열로 변환하기")
+			.verifyComplete();
+		StepVerifier.create(mapFlux)
+			.expectNext("-4를 문자열로 변환하기")
+			.expectNext("-1를 문자열로 변환하기")
+			.expectNext("2를 문자열로 변환하기")
+			.verifyComplete();
+	}
+
+	@Test
+	void useMapRatherThanReturningMonoInFlatMap() {
+		//given
+		Flux<Integer> returnMonoInFlatMapFlux = Flux.just(-1, 0, 1)
+			.flatMap(myNumber -> Mono.just(myNumber + 1));
+
+		Flux<Integer> mapFlux = Flux.just(-1, 0, 1)
+			.map(myNumber -> myNumber + 1);
+
+		//when
+		StepVerifier.create(returnMonoInFlatMapFlux)
+			.expectNext(0)
+			.expectNext(1)
+			.expectNext(2)
+			.verifyComplete();
+		StepVerifier.create(mapFlux)
+			.expectNext(0)
+			.expectNext(1)
+			.expectNext(2)
+			.verifyComplete();
+	}
+
+}

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/MonoFlux_Basic.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/MonoFlux_Basic.java
@@ -1,4 +1,4 @@
-package com.hanghae.lemonairtranscoding.learntest;
+package com.hanghae.lemonairtranscoding.learntest.webflux;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -17,7 +17,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
 import reactor.test.StepVerifier;
 
-public class MonoLearnTest {
+public class MonoFlux_Basic {
 
 	// Mono 역시 Flux와 마찬가지로 Reactive Stream의 Publisher를 상속받은 것을 확인할 수 있습니다.
 	//
@@ -283,7 +283,6 @@ public class MonoLearnTest {
 			}
 			return state + 1;
 		});
-
 		List<Character> sequence1 = characterFlux.take(3).collect(Collectors.toList()).block();
 		List<Character> sequence2 = characterFlux.take(2).collect(Collectors.toList()).block();
 		assert sequence1 != null;

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/PubSubTest.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/PubSubTest.java
@@ -1,4 +1,4 @@
-package com.hanghae.lemonairtranscoding.learntest;
+package com.hanghae.lemonairtranscoding.learntest.webflux;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/SchedulerLearnTest.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/SchedulerLearnTest.java
@@ -1,4 +1,4 @@
-package com.hanghae.lemonairtranscoding.learntest;
+package com.hanghae.lemonairtranscoding.learntest.webflux;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/StreamOperationTest.java
+++ b/src/test/java/com/hanghae/lemonairtranscoding/learntest/webflux/StreamOperationTest.java
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
 import reactor.test.StepVerifier;
 
-public class AvoidFlatMapTest {
+public class StreamOperationTest {
 
 	public Flux<String> getStringFlux(int number) {
 		return Flux.just(String.format("%d를 문자열로 변환하기", number));
@@ -65,7 +65,7 @@ public class AvoidFlatMapTest {
 		// given
 		// 자신의 mock 객체를 만들어서 목객체의 비즈니스로직을 filter 이후에 둬서
 		// filter가 emtpy publisher 인 경우 비즈니스로직이 수행되는지 테스트
-		AvoidFlatMapTest mockThis = Mockito.spy(new AvoidFlatMapTest());
+		StreamOperationTest mockThis = Mockito.spy(new StreamOperationTest());
 		Flux<String> emptyPublisherFlux = Flux.just(-1, 0, 1).filter(i -> i > 2).flatMap(mockThis::myBusinessLogic);
 		// when
 		List<String> results = new ArrayList<>();


### PR DESCRIPTION
트랜스코딩 서버가 열린채 방송 송출, 종료, 송출을 반복했을 때 ffmepg command가 제대로 수행되지 않는 버그 수정,

FFmepgCommandBuilder 클래스에 썸네일 생성 전략(update : 하나의 썸네일만을 생성하며 새로 생성시 동일한 파일명으로 업데이트, sequence : 썸네일 파일에 001, 002 등의 순서가 같이 추력되도록 함) 추가

현재는 썸네일 생성 전략을 update로 10초 간격으로 생성하며 {스트리머이름}/thumbnail/{스트리머이름}_thumbnail.jpg key로 s3에 업로드하도록 추가,