### PR TITLE
feat: 방송 종료 시 Thumbnail Scheduler 종료 코드 작성

### DIFF
--- a/src/main/java/com/hanghae/lemonairtranscoding/controller/TranscodeController.java
+++ b/src/main/java/com/hanghae/lemonairtranscoding/controller/TranscodeController.java
@@ -18,9 +18,15 @@ public class TranscodeController {
 
 	@GetMapping("/{owner}")
 	Mono<Long> startTransCoding(@PathVariable("owner") String email){
+
 		// TODO: 2023-12-05 현재는 obs studio가 보낸 요청으로부터 사용자 정보의 수정 없이 전달되므로
 		//  email 자체가 전송된다. @ 이전 부분만 사용
 		String username = email.substring(0,email.indexOf("@"));
 		return transcodeService.startTranscoding(email, username);
+	}
+
+	@GetMapping("/offair/{owner}")
+	Mono<Boolean> endBroadcast(@PathVariable String owner) {
+		return transcodeService.endBroadcast(owner);
 	}
 }


### PR DESCRIPTION
OBS Studio에서 방송이 종료되어도 Thumbnail을 생성하는 스케쥴러가 계속 동작하는 버그를 수정하였습니다.

현재는 방송 종료 로직이 없는 상태이고,
방송 종료 로직은 rtmp에서 OBS API를 사용하여 이벤트를 감지하는 방식이나
Service server에서 방송 종료 이벤트를 만들어야 합니다.
Postman에서는 정상적으로 동작하는 것을 확인했습니다.